### PR TITLE
Processing parameters are retrieved from Service Context

### DIFF
--- a/multiply_ui/server/context.py
+++ b/multiply_ui/server/context.py
@@ -1,12 +1,15 @@
 from typing import Optional, List
 
 import multiply_data_access.data_access_component
+from multiply_core.models import get_forward_models, ForwardModel
+from multiply_core.observations import INPUT_TYPES
+from multiply_core.variables import get_registered_variables, Variable
 
 from .model import Job
 
 
-
 class ServiceContext:
+
     def __init__(self):
         self._jobs = {}
         self.data_access_component = multiply_data_access.data_access_component.DataAccessComponent()
@@ -30,3 +33,42 @@ class ServiceContext:
 
     def get_jobs(self) -> List[Job]:
         return [job.to_dict() for job in self._jobs.values()]
+
+    @staticmethod
+    def get_available_forward_models() -> List[dict]:
+        dict_list = []
+        forward_models = get_forward_models()
+        for model in forward_models:
+            dict_list.append({
+                "id": model.id,
+                "name": model.name,
+                "description": model.description,
+                "modelAuthors": model.authors,
+                "modelUrl": model.url,
+                "inputType": model.input_type,
+                "variables": model.variables
+            })
+        return dict_list
+
+    @staticmethod
+    def get_available_input_types() -> List[dict]:
+        input_types = []
+        for input_type in INPUT_TYPES:
+            input_types.append({"id": input_type, "name": INPUT_TYPES[input_type]["name"],
+                                "timeRange": INPUT_TYPES[input_type]["name"]})
+        return input_types
+
+    @staticmethod
+    def get_available_variables() -> List[dict]:
+        dict_list = []
+        variables = get_registered_variables()
+        for variable in variables:
+            dict_list.append({
+                "id": variable.short_name,
+                "name": variable.display_name,
+                "unit": variable.unit,
+                "description": variable.description,
+                "valueRange": variable.range,
+                "applications": variable.applications
+            })
+        return dict_list

--- a/multiply_ui/server/controller.py
+++ b/multiply_ui/server/controller.py
@@ -1,10 +1,13 @@
-import json
-import pkg_resources
-
-
 def get_parameters(ctx):
-    json_text = pkg_resources.resource_string(__name__, "resources/processing-parameters.json")
-    return json.loads(json_text)
+    input_type_dicts = ctx.get_available_input_types()
+    variable_dicts = ctx.get_available_variables()
+    forward_model_dicts = ctx.get_available_forward_models()
+    parameters = {
+        "inputTypes": input_type_dicts,
+        "variables": variable_dicts,
+        "forwardModels": forward_model_dicts
+    }
+    return parameters
 
 
 def get_inputs(ctx, parameters):

--- a/test/server/test_controller.py
+++ b/test/server/test_controller.py
@@ -2,19 +2,18 @@ import json
 import os
 import unittest
 
-from multiply_ui.server import controller
+from multiply_ui.server import context, controller
 
 
 class ControllerTest(unittest.TestCase):
 
     def test_get_parameters(self):
-        parameters = controller.get_parameters(None)
+        parameters = controller.get_parameters(context.ServiceContext())
         self.assertEqual(1, len(parameters["inputTypes"]))
         self.assertEqual(parameters["inputTypes"][0]["name"], "Sentinel-2 MSI L1C")
 
     @unittest.skipIf(os.environ.get('MULTIPLY_DISABLE_WEB_TESTS') == '1', 'MULTIPLY_DISABLE_WEB_TESTS = 1')
     def test_get_inputs(self):
-        from multiply_ui.server import context
         with open(os.path.join(os.path.dirname(__file__), '..', 'test_data', 'example_request_parameters.json')) as fp:
             json_text = fp.read()
             parameters = json.loads(json_text)


### PR DESCRIPTION
... and not read from a static JSON file anymore. To use this, please update your version of multiply-core to the latest version.

If you still want to see the S2 prosail forward model in your notebook:
- Download http://www2.geog.ucl.ac.uk/~ucfajlg/emulators/spectral/prosail/metadata.json and place it in a folder of your choice.
- in your multiply-ui environment, start python
- $ from multiply_core.models import resgister_forward_model
- $ register_forward_model(<path_to_file>)